### PR TITLE
Fixed plugin build SDK, updated Firebase to latest

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -8,7 +8,7 @@ buildscript {
     }
 
     dependencies {
-        classpath 'com.android.tools.build:gradle:3.1.4'
+        classpath 'com.android.tools.build:gradle:3.3.0'
     }
 }
 
@@ -22,7 +22,7 @@ rootProject.allprojects {
 apply plugin: 'com.android.library'
 
 android {
-    compileSdkVersion 27
+    compileSdkVersion 28
 
     defaultConfig {
         minSdkVersion 21
@@ -33,8 +33,8 @@ android {
     }
 
     dependencies {
-        api 'com.android.support:support-annotations:27.1.1'
-        api 'com.google.firebase:firebase-ml-vision:18.0.1'
-        api 'com.google.firebase:firebase-core:16.0.5'
+        api 'androidx.annotation:annotation:1.0.0'
+        api 'com.google.firebase:firebase-ml-vision:19.0.2'
+        api 'com.google.firebase:firebase-core:16.0.7'
     }
 }


### PR DESCRIPTION
The build SDK for the plugin was still set at 27 instead of the required 28.  This created problems with CI/CD servers and command line builds even though Flutter and Android Studio seemed to find a way around it.

The specific error this resolves is:
```
Execution failed for task ':fast_qr_reader_view:verifyReleaseResources'.
> java.util.concurrent.ExecutionException: com.android.builder.internal.aapt.v2.Aapt2Exception: Android resource linking failed
  Output:  /.../build/fast_qr_reader_view/intermediates/res/merged/release/values/values.xml:197: error: resource android:attr/fontVariationSettings not found.
  /.../build/fast_qr_reader_view/intermediates/res/merged/release/values/values.xml:198: error: resource android:attr/ttcIndex not found.
  error: failed linking references.        
```