### PR TITLE
Do not try to call permissionResult.success for any permission request

### DIFF
--- a/android/src/main/java/co/apperto/fastqrreaderview/FastQrReaderViewPlugin.java
+++ b/android/src/main/java/co/apperto/fastqrreaderview/FastQrReaderViewPlugin.java
@@ -213,7 +213,7 @@ public class FastQrReaderViewPlugin implements MethodCallHandler, PluginRegistry
             }
             return true;
         }
-        permissionResult.success("unknown");
+
         return false;
     }
 


### PR DESCRIPTION
This line causes the app to crash if anything in the app has performed a permission request, because the `onRequestPermissionsResult` will be called for every permission request.